### PR TITLE
Note 스키마 및 타입 추가

### DIFF
--- a/src/entities/note/index.ts
+++ b/src/entities/note/index.ts
@@ -1,0 +1,35 @@
+import {
+  NoteSchema,
+  NoteCreateSchema,
+  NoteCateSchema,
+  NoteCateCreateSchema,
+  NoteLabelSchema,
+  NoteLabelCreateSchema,
+} from "./model/schema";
+
+import type {
+  Note,
+  NoteCreate,
+  NoteCate,
+  NoteCateCreate,
+  NoteLabel,
+  NoteLabelCreate,
+} from "./model/type";
+
+export {
+  NoteSchema,
+  NoteCreateSchema,
+  NoteCateSchema,
+  NoteCateCreateSchema,
+  NoteLabelSchema,
+  NoteLabelCreateSchema,
+};
+
+export type {
+  Note,
+  NoteCreate,
+  NoteCate,
+  NoteCateCreate,
+  NoteLabel,
+  NoteLabelCreate,
+};

--- a/src/entities/note/model/schema.ts
+++ b/src/entities/note/model/schema.ts
@@ -1,0 +1,31 @@
+import { IdSchema } from "@shared/common/schema/idSchema";
+import { z } from "zod";
+
+export const NoteCateSchema = z.object({
+  id: IdSchema,
+  name: z.string().min(1, { message: "카테고리 이름은 필수입니다." }),
+  order: z.number().default(0),
+}).strict();
+export const NoteCateCreateSchema = NoteCateSchema.omit({ id: true }).strict();
+
+export const NoteLabelSchema = z.object({
+  id: IdSchema,
+  name: z.string().min(1, { message: "라벨 이름은 필수입니다." }),
+  order: z.number().default(0),
+  color: z.string().min(1, { message: "라벨 색상은 필수입니다." }),
+}).strict();
+export const NoteLabelCreateSchema = NoteLabelSchema.omit({ id: true }).strict();
+
+export const NoteSchema = z.object({
+  id: IdSchema,
+  title: z.string().min(1, { message: "노트 제목은 필수입니다." }),
+  content: z.string().min(1, { message: "노트 내용은 필수입니다." }).default(""),
+  order: z.number().default(0),
+  cateId: IdSchema.optional(),
+  label: NoteLabelSchema.nullable().optional(),
+  isImportant: z.boolean().default(false),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).strict();
+export const NoteCreateSchema = NoteSchema.omit({ id: true }).strict();
+

--- a/src/entities/note/model/type.ts
+++ b/src/entities/note/model/type.ts
@@ -1,0 +1,11 @@
+import type { z } from "zod";
+import type { NoteCateCreateSchema, NoteCateSchema, NoteCreateSchema, NoteLabelCreateSchema, NoteLabelSchema, NoteSchema } from "./schema";
+
+export type NoteCate = z.infer<typeof NoteCateSchema>;
+export type NoteCateCreate = z.infer<typeof NoteCateCreateSchema>;
+
+export type NoteLabel = z.infer<typeof NoteLabelSchema>;
+export type NoteLabelCreate = z.infer<typeof NoteLabelCreateSchema>;
+
+export type Note = z.infer<typeof NoteSchema>;
+export type NoteCreate = z.infer<typeof NoteCreateSchema>;


### PR DESCRIPTION
[작업 내용]
Note 관련 스키마 및 타입 정의 추가 (Zod 기반)
Note, NoteLabel, NoteCate 각각에 대해 Schema, CreateSchema, Type 분리
strict() 사용으로 불필요 필드 제한

[목적]
노트 기능 개발을 위한 초기 모델링
타입 안정성 및 유효성 검증 기반 확보

[기타]
/entities/note/model 구조 기준에 맞춰 정리됨