### PR TITLE
백엔드 indexedDB 세팅

### DIFF
--- a/src/backend/config/indexedDbConfig.ts
+++ b/src/backend/config/indexedDbConfig.ts
@@ -1,0 +1,29 @@
+import Dexie, { type EntityTable } from "dexie";
+import type { Note, NoteCate, NoteLabel } from "@entities/note";
+import type { Todo, TodoCate, TodoLabel } from "@entities/todo";
+
+export interface FlowaDb extends Dexie {
+  todoCate: EntityTable<TodoCate, "id">;
+  todoLabel: EntityTable<TodoLabel, "id">;
+  todo: EntityTable<Todo, "id">;
+  noteCate: EntityTable<NoteCate, "id">;
+  noteLabel: EntityTable<NoteLabel, "id">;
+  note: EntityTable<Note, "id">;
+}
+
+export function createFlowaDb(dbName: string = "flowa2Db"): FlowaDb {
+  const db = new Dexie(dbName) as FlowaDb;
+
+  db.version(1).stores({
+    todoCate: "++id, name, order",
+    todo: "++id, title, isDone, sub, order, isImportant, startDate, endDate, repeatType, repeatDate, memo, cateId, doneDate",
+    todoLabel: "++id, name, order, color",
+    noteCate: "++id, name, order",
+    noteLabel: "++id, name, order, color",
+    note: "++id, title, order, isImportant, content, labelId, cateId, createdAt, updatedAt",
+  });
+
+  return db;
+}
+
+export const flowaDb = createFlowaDb();


### PR DESCRIPTION
[backend] local IndexedDB (Dexie) 초기 설정 및 엔티티 정의

- flowa2Db Dexie 인스턴스 생성
- note, noteCate, noteLabel, todo, todoCate, todoLabel 테이블 정의
- EntityTable을 통한 TypeScript 타입 안정성 확보
- 테스트 코드는 Dexie 환경 이슈로 제외 (fake-indexeddb 미사용 결정)
