### PR TITLE
[back] todoCate service

### DIFF
--- a/src/backend/todo/repository/TodoCateRepository.ts
+++ b/src/backend/todo/repository/TodoCateRepository.ts
@@ -8,7 +8,7 @@ class TodoCateRepository {
     return todoCates;
   }
 
-  public async getById(id: number): Promise<TodoCateEntity | undefined> {
+  public async getById(id: number | string): Promise<TodoCateEntity | undefined> {
     const todoCate = await flowaDb.todoCate.get(id) as TodoCateEntity;
 
     return todoCate;

--- a/src/backend/todo/service/TodoCateBackService.ts
+++ b/src/backend/todo/service/TodoCateBackService.ts
@@ -1,0 +1,51 @@
+import type { TodoCateCreateEntity, TodoCateEntity } from "../domain/TodoCateEntity";
+import TodoCateRepository from "../repository/TodoCateRepository";
+import { todoRepository } from "../repository/TodoRepository";
+
+class TodoCateBackService {
+  private todoCateRepository = TodoCateRepository;
+  private todoRepository = todoRepository;
+
+  public async getAll(): Promise<TodoCateEntity[]> {
+    const todoCates = await this.todoCateRepository.getAll();
+    return todoCates.sort((a, b) => {
+      return a.order - b.order;
+    });
+  }
+
+  public async save(todoCate: TodoCateEntity | TodoCateCreateEntity): Promise<void> {
+    if ("id" in todoCate) {
+      await this.todoCateRepository.save(todoCate);
+    } else {
+      todoCate.order = await this.newOrder();
+      await this.todoCateRepository.save(todoCate);
+    }
+  }
+
+  public async delete(id: number): Promise<void> {
+    const todoListByCateId = await this.todoRepository.findByCateId(id);
+    if (todoListByCateId.length > 0) {
+      for (const todo of todoListByCateId) {
+        await this.todoRepository.deleteById(todo.id);
+      }
+    }
+    await this.todoCateRepository.delete(id);
+  }
+
+  public async findById(id: number | string): Promise<TodoCateEntity | undefined> {
+    const todoCate = await this.todoCateRepository.getById(id);
+    return todoCate;
+  }
+
+  private async newOrder(): Promise<number> {
+    const todoCates = await this.todoCateRepository.getAll();
+    const maxOrder = todoCates.reduce((max, todoCate) => {
+      return Math.max(max, todoCate.order);
+    }, 0);
+
+    return maxOrder + 1;
+  }
+  
+}
+
+export default new TodoCateBackService();


### PR DESCRIPTION
TodoCateBackService 클래스 구현
TODO 카테고리 관련 비즈니스 로직 담당
전체 조회, 저장(order 자동 계산 포함), 단건 조회, 삭제 기능 포함
삭제 시 해당 카테고리에 속한 TODO들도 함께 제거
newOrder() 메서드로 order 자동 증가 방식 적용