### PR TITLE
ContextMenu 컴포넌트 추가

### DIFF
--- a/src/shared/components/contextMenu/index.ts
+++ b/src/shared/components/contextMenu/index.ts
@@ -1,0 +1,5 @@
+import ContextMenu from "./ui/ContextMenu";
+import { ContextMenuStore } from "./model/ContextMenuStore";
+import useContextMenuAction from "./model/useContextMenuAction";
+
+export { ContextMenu, useContextMenuAction, ContextMenuStore };

--- a/src/shared/components/contextMenu/model/ContextMenuStore.ts
+++ b/src/shared/components/contextMenu/model/ContextMenuStore.ts
@@ -1,0 +1,28 @@
+import { atom } from "recoil";
+import type { ContextMenuStoreType } from "./type";
+
+export const ContextMenuStore = atom<ContextMenuStoreType>({
+  key: "ContextMenuStore",
+  default: {
+    isOpen: false,
+    position: { x: 0, y: 0 },
+    items: [],
+  },
+  effects_UNSTABLE: [
+    ({ setSelf }) => {
+      const handleClick = () => {
+        setSelf({
+          isOpen: false,
+          position: { x: 0, y: 0 },
+          items: [],
+        });
+      };
+
+      window.addEventListener("click", handleClick);
+
+      return () => {
+        window.removeEventListener("click", handleClick);
+      };
+    },
+  ],
+});

--- a/src/shared/components/contextMenu/model/type.ts
+++ b/src/shared/components/contextMenu/model/type.ts
@@ -1,0 +1,10 @@
+export type ContextMenuItemType = {
+  label: string;
+  onClick: () => void;
+};
+
+export type ContextMenuStoreType = {
+  isOpen: boolean;
+  position: { x: number; y: number };
+  items: ContextMenuItemType[];
+}

--- a/src/shared/components/contextMenu/model/useContextMenuAction.ts
+++ b/src/shared/components/contextMenu/model/useContextMenuAction.ts
@@ -1,0 +1,30 @@
+import { useSetRecoilState } from "recoil";
+import { ContextMenuStore } from "./ContextMenuStore";
+import type { ContextMenuItemType } from "./type";
+
+const useContextMenuAction = (items: ContextMenuItemType[]) => {
+  const set = useSetRecoilState(ContextMenuStore);
+
+  const onContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+    const { clientX, clientY } = event;
+
+    set({
+      isOpen: true,
+      position: { x: clientX, y: clientY },
+      items,
+    });
+  };
+
+  const close = () => {
+    set({
+      isOpen: false,
+      position: { x: 0, y: 0 },
+      items: [],
+    });
+  };
+
+  return { onContextMenu, close };
+}
+
+export default useContextMenuAction;

--- a/src/shared/components/contextMenu/ui/ContextMenu.style.ts
+++ b/src/shared/components/contextMenu/ui/ContextMenu.style.ts
@@ -1,0 +1,28 @@
+import type { Theme } from "@emotion/react";
+
+export type ContextMenuLocation = {
+  x: number;
+  y: number;
+};
+export const contextMenuStyles = {
+  container:
+    ({ x = 0, y = 0 }: ContextMenuLocation) =>
+    (theme: Theme) =>
+      ({
+        display: "flex",
+        flexDirection: "column",
+        position: "absolute",
+        top: y,
+        left: x,
+        zIndex: 10000,
+        width: "fit-content",
+        minWidth: "80px",
+        minHeight: "20px",
+        gap: "2px",
+        backgroundColor: theme.colors.background.deep,
+        borderRadius: theme.radius.small,
+        boxShadow: theme.shadow.small,
+        overflow: "hidden",
+        padding: "5px",
+      } as const),
+};

--- a/src/shared/components/contextMenu/ui/ContextMenu.tsx
+++ b/src/shared/components/contextMenu/ui/ContextMenu.tsx
@@ -1,0 +1,28 @@
+/** @jsxImportSource @emotion/react */
+
+import { useRecoilValue } from "recoil";
+import type { ContextMenuItemType } from "../model/type";
+import { contextMenuStyles } from "./ContextMenu.style";
+import ContextMenuItem from "./ContextMenuItem";
+import { ContextMenuStore } from "../model/ContextMenuStore";
+
+function ContextMenu() {
+  const { container } = contextMenuStyles;
+  const { isOpen, position, items } = useRecoilValue(ContextMenuStore);
+
+  if (!isOpen) return null;
+
+  return (
+    <div css={container(position)}>
+      {items.map((item: ContextMenuItemType) => (
+        <ContextMenuItem
+          key={item.label}
+          label={item.label}
+          onClick={item.onClick}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default ContextMenu;

--- a/src/shared/components/contextMenu/ui/ContextMenuItem.style.ts
+++ b/src/shared/components/contextMenu/ui/ContextMenuItem.style.ts
@@ -1,0 +1,16 @@
+import type { Theme } from "@emotion/react";
+
+export const contextMenuItemStyles = {
+  container: (theme: Theme) => ({
+    width: "100%",
+    padding: "5px 10px",
+    fontSize: "12px",
+    backgroundColor: "transparent",
+    color: theme.colors.text.primary,
+    cursor: "pointer",
+    "&:hover": {
+      transition: "none",
+      backgroundColor: theme.colors.background.hover,
+    },
+  }),
+};

--- a/src/shared/components/contextMenu/ui/ContextMenuItem.tsx
+++ b/src/shared/components/contextMenu/ui/ContextMenuItem.tsx
@@ -1,0 +1,18 @@
+/** @jsxImportSource @emotion/react */
+
+import { ContextMenuItemType } from "../model/type";
+import { contextMenuItemStyles } from "./ContextMenuItem.style";
+
+function ContextMenuItem({
+  label,
+  onClick,
+}: ContextMenuItemType) {
+  const { container } = contextMenuItemStyles;
+  return (
+    <div css={container} onClick={onClick}>
+      {label}
+    </div>
+  );
+}
+
+export default ContextMenuItem;


### PR DESCRIPTION
ContextMenu
- 컨텍스트 메뉴 UI
- 전역 프로바이더에 렌더링 할 것 

useContextMenuAction
- props: items { label: string, onClick: () => void }[]
- return: onContext(element에 onContext 바로 넣을 것), close( 닫기 함수, 기본적으로 context menu 외부 클릭시 작동 )

ContextMenuStore
- isOpen: boolean
- position: { x: number, y: number }
- items: { label: string, onClick: () => void }[]


사용 예시 
[프로바이더]
function ContextMenuProvider ({ children} ){
  return (
    <>
      {children}
      <ContextMenu />
    </>
  )
}

[적용 컴포넌트]
function Example() {
  const { onContextMenu } = useContextMenuAction([
    { label: "삭제", onClick: () => console.log("삭제 함수 실행") },
    { label: "수정", onClick: () => console.log("수정 함수 실행") },
  ])

  return (
    <div onContextMenu={onContextMenu}>
      Todo
    </div>
  )
}
